### PR TITLE
Repair and refine secondary festival pages

### DIFF
--- a/about.php
+++ b/about.php
@@ -4,79 +4,68 @@ $title = 'About Us';
 include 'includes/header.php';
 ?>
 
-<section class="about">
-  <div class="about-text">
-    <h2>About Us</h2>
-    <p>
-      We are passionate about turning curiosity into creativity.  
-      Our mission is to make STEM education inspiring and accessible to everyone — 
-      helping young minds explore, experiment, and build a smarter future.
-    </p>
-    <div class="about-cards">
-      <div class="about-card">
-        <h3>Our Mission</h3>
-        <p>To empower learners through hands-on STEM experiences that spark curiosity and confidence.</p>
-      </div>
-      <div class="about-card">
-        <h3>Our Vision</h3>
-        <p>A world where innovation and critical thinking are part of everyday learning.</p>
-      </div>
-    </div>
-    <a href="projects.php" class="about-btn">See Our Students' Work →</a>
-    <section id="presentations">
-      <h2>Student Projects</h2>
+<link href="assets/css/secondary-pages.css" rel="stylesheet">
+
+<div class="secondary-page">
+    <section class="secondary-hero" aria-labelledby="about-title">
+        <div class="secondary-hero-copy">
+            <p class="eyebrow">About the festival</p>
+            <h1 id="about-title">Where student curiosity becomes visible work</h1>
+            <p class="lead">Paradis Science Festival is a public showcase, project platform and archive for student-led science, engineering and interdisciplinary learning.</p>
+        </div>
+        <div class="secondary-hero-media">
+            <img src="assets/images/experiments kids.jpg" alt="Students conducting science experiments">
+        </div>
     </section>
-  </div>
-</section>
 
-<div class="container">
-  <img src="assets/images/experiments kids.jpg" alt="Children conducting science experiments" style="width:100%;">
-  <div class="content">
-    <h1>Science Fair</h1>
-    <p>Inspired by the genius of Nikola Tesla, our Science Fair Festival celebrates the power of imagination, innovation, and discovery. It is where ideas spark into reality, where students transform curiosity into invention, and where the next generation of creators dares to shape the future — just as Tesla did.</p>
-  </div>
+    <section aria-labelledby="purpose-title">
+        <div class="section-heading">
+            <div>
+                <p class="eyebrow">Purpose</p>
+                <h2 id="purpose-title">More than a one-day exhibition</h2>
+            </div>
+            <p>The festival gives students a place to investigate, build, present and revisit their work over time.</p>
+        </div>
+        <div class="secondary-grid">
+            <article class="secondary-card">
+                <h3>Learn through making</h3>
+                <p>Students test ideas through experiments, prototypes, observation, research and iteration.</p>
+            </article>
+            <article class="secondary-card">
+                <h3>Present with confidence</h3>
+                <p>Projects are explained to peers, teachers, families and external guests in a public setting.</p>
+            </article>
+            <article class="secondary-card">
+                <h3>Connect disciplines</h3>
+                <p>Science, engineering, design, ecology, chemistry and digital tools meet in practical work.</p>
+            </article>
+            <article class="secondary-card">
+                <h3>Build an archive</h3>
+                <p>Projects, publications, media and results remain available beyond the event itself.</p>
+            </article>
+        </div>
+    </section>
+
+    <section class="secondary-grid" aria-label="Mission and vision">
+        <article class="secondary-card">
+            <p class="eyebrow">Mission</p>
+            <h2>Make STEM active and accessible</h2>
+            <p>We create structured opportunities for students to ask better questions, develop practical skills and communicate what they discover.</p>
+        </article>
+        <article class="secondary-card">
+            <p class="eyebrow">Vision</p>
+            <h2>A school culture where ideas are built</h2>
+            <p>We want experimentation, collaboration and responsible innovation to become normal parts of everyday learning.</p>
+        </article>
+    </section>
+
+    <section class="secondary-cta" aria-labelledby="about-cta-title">
+        <div>
+            <h2 id="about-cta-title">See what students have created</h2>
+            <p>Browse current projects, project films and bilingual publications.</p>
+        </div>
+        <a href="projects.php" class="platform-link primary">Browse projects</a>
+    </section>
 </div>
-
-<section id="about" class="about section">
-  <div class="about-wrap">
-    <!-- Tesla Quote -->
-    <blockquote class="about-quote">
-      "The present is theirs; the future, for which I really worked, is mine."
-      <span>— Nikola Tesla</span>
-    </blockquote>
-
-    <div class="about-grid">
-      <div class="about-feature">
-        <div class="about-icon">💡</div>
-        <h3>Hands-On Learning</h3>
-        <p>Students build real prototypes, run experiments, and learn by doing — not just reading.</p>
-      </div>
-
-      <div class="about-feature">
-        <div class="about-icon">🤝</div>
-        <h3>Collaboration</h3>
-        <p>We foster teamwork, mentorship, and peer-to-peer learning in every project.</p>
-      </div>
-
-      <div class="about-feature">
-        <div class="about-icon">🌍</div>
-        <h3>Real-World Impact</h3>
-        <p>From sustainability to technology, our projects address challenges that matter.</p>
-      </div>
-
-      <div class="about-feature">
-        <div class="about-icon">🚀</div>
-        <h3>Future-Ready Skills</h3>
-        <p>Critical thinking, coding, design — students gain skills for tomorrow's careers.</p>
-      </div>
-    </div>
-
-    <div class="about-cta">
-      <h3>Join the Movement</h3>
-      <p>Whether you're a student, teacher, or supporter — there's a place for you in our STEM community.</p>
-      <a href="community.php" class="btn btn-primary">Get Involved →</a>
-    </div>
-  </div>
-</section>
 
 <?php include 'includes/footer.php'; ?>

--- a/about.php
+++ b/about.php
@@ -1,10 +1,9 @@
 <?php
 require_once 'includes/functions.php';
 $title = 'About Us';
+$extraStylesheets = ['assets/css/secondary-pages.css'];
 include 'includes/header.php';
 ?>
-
-<link href="assets/css/secondary-pages.css" rel="stylesheet">
 
 <div class="secondary-page">
     <section class="secondary-hero" aria-labelledby="about-title">
@@ -20,50 +19,24 @@ include 'includes/header.php';
 
     <section aria-labelledby="purpose-title">
         <div class="section-heading">
-            <div>
-                <p class="eyebrow">Purpose</p>
-                <h2 id="purpose-title">More than a one-day exhibition</h2>
-            </div>
+            <div><p class="eyebrow">Purpose</p><h2 id="purpose-title">More than a one-day exhibition</h2></div>
             <p>The festival gives students a place to investigate, build, present and revisit their work over time.</p>
         </div>
         <div class="secondary-grid">
-            <article class="secondary-card">
-                <h3>Learn through making</h3>
-                <p>Students test ideas through experiments, prototypes, observation, research and iteration.</p>
-            </article>
-            <article class="secondary-card">
-                <h3>Present with confidence</h3>
-                <p>Projects are explained to peers, teachers, families and external guests in a public setting.</p>
-            </article>
-            <article class="secondary-card">
-                <h3>Connect disciplines</h3>
-                <p>Science, engineering, design, ecology, chemistry and digital tools meet in practical work.</p>
-            </article>
-            <article class="secondary-card">
-                <h3>Build an archive</h3>
-                <p>Projects, publications, media and results remain available beyond the event itself.</p>
-            </article>
+            <article class="secondary-card"><h3>Learn through making</h3><p>Students test ideas through experiments, prototypes, observation, research and iteration.</p></article>
+            <article class="secondary-card"><h3>Present with confidence</h3><p>Projects are explained to peers, teachers, families and external guests in a public setting.</p></article>
+            <article class="secondary-card"><h3>Connect disciplines</h3><p>Science, engineering, design, ecology, chemistry and digital tools meet in practical work.</p></article>
+            <article class="secondary-card"><h3>Build an archive</h3><p>Projects, publications, media and results remain available beyond the event itself.</p></article>
         </div>
     </section>
 
     <section class="secondary-grid" aria-label="Mission and vision">
-        <article class="secondary-card">
-            <p class="eyebrow">Mission</p>
-            <h2>Make STEM active and accessible</h2>
-            <p>We create structured opportunities for students to ask better questions, develop practical skills and communicate what they discover.</p>
-        </article>
-        <article class="secondary-card">
-            <p class="eyebrow">Vision</p>
-            <h2>A school culture where ideas are built</h2>
-            <p>We want experimentation, collaboration and responsible innovation to become normal parts of everyday learning.</p>
-        </article>
+        <article class="secondary-card"><p class="eyebrow">Mission</p><h2>Make STEM active and accessible</h2><p>We create structured opportunities for students to ask better questions, develop practical skills and communicate what they discover.</p></article>
+        <article class="secondary-card"><p class="eyebrow">Vision</p><h2>A school culture where ideas are built</h2><p>We want experimentation, collaboration and responsible innovation to become normal parts of everyday learning.</p></article>
     </section>
 
     <section class="secondary-cta" aria-labelledby="about-cta-title">
-        <div>
-            <h2 id="about-cta-title">See what students have created</h2>
-            <p>Browse current projects, project films and bilingual publications.</p>
-        </div>
+        <div><h2 id="about-cta-title">See what students have created</h2><p>Browse current projects, project films and bilingual publications.</p></div>
         <a href="projects.php" class="platform-link primary">Browse projects</a>
     </section>
 </div>

--- a/assets/css/listing-pages.css
+++ b/assets/css/listing-pages.css
@@ -1,0 +1,185 @@
+/* Project archive, news and project-detail refinements. */
+.navbar-account .nav-action {
+    background: #ffffff !important;
+    color: #07154f !important;
+    border: 1px solid rgba(255,255,255,.9);
+    box-shadow: 0 5px 16px rgba(0,0,0,.16);
+}
+
+.navbar-account .nav-action:hover,
+.navbar-account .nav-action:focus-visible {
+    background: #8eeafa !important;
+    color: #07154f !important;
+}
+
+.archive-hero,
+.news-hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 2rem;
+    align-items: end;
+    padding: clamp(1.5rem, 4vw, 3rem);
+    border: 1px solid var(--festival-border);
+    border-radius: 22px;
+    background: linear-gradient(135deg, #f9fcff, #eef6ff);
+    box-shadow: var(--festival-shadow);
+}
+
+.archive-hero h1,
+.news-hero h1 {
+    margin: .2rem 0 .7rem;
+    font-size: clamp(2rem, 5vw, 4rem);
+    line-height: 1;
+    letter-spacing: -.04em;
+}
+
+.archive-actions,
+.news-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+    justify-content: flex-end;
+}
+
+.archive-toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .75rem;
+    margin: 1.5rem 0;
+    padding: 1rem;
+    border: 1px solid var(--festival-border);
+    border-radius: 16px;
+    background: #fff;
+}
+
+.archive-toolbar form { margin: 0 !important; }
+
+.archive-toolbar select {
+    min-height: 44px;
+    padding: 0 .9rem;
+    border: 1px solid #c8d4e3;
+    border-radius: 10px;
+    background: #fff;
+    color: var(--festival-ink);
+    font-weight: 650;
+}
+
+.project-archive-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1.1rem;
+}
+
+.project-archive-card {
+    overflow: hidden;
+    border: 1px solid var(--festival-border);
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 12px 30px rgba(15,35,75,.08);
+    transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.project-archive-card:hover,
+.project-archive-card:focus-within {
+    transform: translateY(-3px);
+    box-shadow: 0 18px 40px rgba(15,35,75,.13);
+}
+
+.project-archive-link {
+    display: flex;
+    height: 100%;
+    flex-direction: column;
+    color: inherit;
+    text-decoration: none;
+}
+
+.project-archive-thumb {
+    display: grid;
+    place-items: center;
+    min-height: 170px;
+    background: linear-gradient(135deg, #0b2a68, #1276a8);
+    color: #fff;
+    font-size: 2.5rem;
+}
+
+.project-archive-body {
+    display: flex;
+    min-height: 220px;
+    flex: 1;
+    flex-direction: column;
+    padding: 1.2rem;
+}
+
+.project-archive-body h2 {
+    margin: 0 0 .55rem;
+    font-size: 1.2rem;
+}
+
+.project-archive-body p { color: var(--festival-muted); }
+.project-archive-meta { margin-top: auto; }
+.project-archive-meta-row { display:flex; justify-content:space-between; gap:.75rem; align-items:center; }
+.project-archive-author { margin:.7rem 0 0; font-size:.9rem; }
+
+.news-grid-modern {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+    margin-top: 1.5rem;
+}
+
+.news-document-card,
+.news-year-card {
+    padding: 1.2rem;
+    border: 1px solid var(--festival-border);
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 10px 28px rgba(15,35,75,.07);
+}
+
+.news-document-card h2,
+.news-year-card h2 { margin: 0 0 .45rem; font-size:1.2rem; }
+.news-document-card p,
+.news-year-card p { color: var(--festival-muted); }
+.news-document-actions { display:flex; flex-wrap:wrap; gap:.6rem; margin-top:1rem; }
+
+.project-detail-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(270px, 340px);
+    gap: 1.25rem;
+    align-items: start;
+}
+
+.project-detail-main,
+.project-detail-sidebar > section {
+    border: 1px solid var(--festival-border);
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 10px 28px rgba(15,35,75,.07);
+}
+
+.project-detail-main { overflow:hidden; }
+.project-detail-heading { padding:1.35rem; border-bottom:1px solid var(--festival-border); background:#f8fbff; }
+.project-detail-heading h1 { margin:0 0 .35rem; font-size:clamp(1.8rem,4vw,3rem); }
+.project-detail-content { padding:1.35rem; }
+.project-detail-sidebar { display:grid; gap:1rem; }
+.project-detail-sidebar > section { padding:1.15rem; }
+.project-detail-sidebar h2 { font-size:1.05rem; }
+
+@media (max-width: 900px) {
+    .archive-hero,
+    .news-hero,
+    .project-detail-layout {
+        grid-template-columns: 1fr;
+    }
+    .archive-actions,
+    .news-actions { justify-content:flex-start; }
+    .project-archive-grid { grid-template-columns:repeat(2,minmax(0,1fr)); }
+}
+
+@media (max-width: 640px) {
+    .project-archive-grid,
+    .news-grid-modern { grid-template-columns:1fr; }
+    .archive-toolbar { display:grid; }
+    .archive-toolbar form,
+    .archive-toolbar select { width:100%; }
+}

--- a/assets/css/secondary-pages.css
+++ b/assets/css/secondary-pages.css
@@ -132,9 +132,29 @@
 }
 
 .value-card summary {
+    width: fit-content;
     cursor: pointer;
     color: #0b5ea8;
     font-weight: 750;
+}
+
+.value-card summary:hover {
+    text-decoration: underline;
+    text-underline-offset: .2em;
+}
+
+.value-card summary:focus-visible {
+    outline: 3px solid rgba(23, 105, 170, .35);
+    outline-offset: 4px;
+    border-radius: 4px;
+}
+
+.value-card details[open] summary {
+    margin-bottom: .55rem;
+}
+
+.value-card details p:last-child {
+    margin-bottom: 0;
 }
 
 .secondary-cta {
@@ -164,5 +184,26 @@
     .secondary-grid,
     .values-grid {
         grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 600px) {
+    .secondary-hero {
+        padding: 1.25rem;
+        border-radius: 18px;
+    }
+
+    .secondary-hero h1 {
+        font-size: clamp(2rem, 11vw, 3rem);
+    }
+
+    .secondary-cta,
+    .secondary-cta .platform-actions {
+        align-items: stretch;
+    }
+
+    .secondary-cta .platform-actions,
+    .secondary-cta .platform-link {
+        width: 100%;
     }
 }

--- a/assets/css/secondary-pages.css
+++ b/assets/css/secondary-pages.css
@@ -1,0 +1,168 @@
+/* Focused layouts for About and Community pages. */
+.secondary-page {
+    display: grid;
+    gap: clamp(2rem, 5vw, 4.5rem);
+    padding-bottom: clamp(2rem, 6vw, 5rem);
+}
+
+.secondary-hero {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: minmax(0, 1.1fr) minmax(280px, .9fr);
+    gap: clamp(1.5rem, 4vw, 3.5rem);
+    align-items: center;
+    padding: clamp(1.5rem, 5vw, 4rem);
+    border: 1px solid var(--festival-border);
+    border-radius: 24px;
+    background: linear-gradient(135deg, #f8fbff 0%, #eef5ff 65%, #f7f4ff 100%);
+    box-shadow: var(--festival-shadow);
+}
+
+.secondary-hero::after {
+    content: "";
+    position: absolute;
+    width: 240px;
+    height: 240px;
+    right: -80px;
+    top: -100px;
+    border-radius: 50%;
+    background: rgba(65, 168, 255, .13);
+    pointer-events: none;
+}
+
+.secondary-hero-copy {
+    position: relative;
+    z-index: 1;
+}
+
+.secondary-hero h1 {
+    margin: 0 0 .8rem;
+    max-width: 760px;
+    font-size: clamp(2.2rem, 5vw, 4.4rem);
+    line-height: 1.02;
+    letter-spacing: -.04em;
+}
+
+.secondary-hero .lead {
+    max-width: 700px;
+    margin: 0;
+    color: var(--festival-muted);
+    font-size: clamp(1rem, 2vw, 1.2rem);
+}
+
+.secondary-hero-media {
+    position: relative;
+    z-index: 1;
+}
+
+.secondary-hero-media img {
+    display: block;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    object-fit: cover;
+    border-radius: 18px;
+    box-shadow: 0 20px 46px rgba(9, 31, 73, .16);
+}
+
+.secondary-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1.2rem;
+}
+
+.secondary-card {
+    padding: clamp(1.3rem, 3vw, 2rem);
+    border: 1px solid var(--festival-border);
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 12px 30px rgba(15, 35, 75, .08);
+}
+
+.secondary-card h2,
+.secondary-card h3 {
+    margin-top: 0;
+}
+
+.secondary-card p:last-child {
+    margin-bottom: 0;
+}
+
+.values-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.value-card {
+    display: flex;
+    flex-direction: column;
+    min-height: 100%;
+    padding: 1.35rem;
+    border: 1px solid var(--festival-border);
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 10px 26px rgba(15, 35, 75, .07);
+}
+
+.value-icon {
+    display: inline-grid;
+    place-items: center;
+    width: 42px;
+    height: 42px;
+    margin-bottom: 1rem;
+    border-radius: 12px;
+    background: #eaf4ff;
+    color: #0b5ea8;
+    font-size: 1.2rem;
+}
+
+.value-card h3 {
+    margin: 0 0 .55rem;
+    font-size: 1.15rem;
+}
+
+.value-card p {
+    color: var(--festival-muted);
+}
+
+.value-card details {
+    margin-top: auto;
+    padding-top: .6rem;
+}
+
+.value-card summary {
+    cursor: pointer;
+    color: #0b5ea8;
+    font-weight: 750;
+}
+
+.secondary-cta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.2rem;
+    padding: clamp(1.4rem, 4vw, 2.5rem);
+    border-radius: 20px;
+    background: #0d315f;
+    color: #fff;
+}
+
+.secondary-cta h2,
+.secondary-cta p {
+    color: inherit;
+}
+
+.secondary-cta p {
+    margin-bottom: 0;
+    opacity: .88;
+}
+
+@media (max-width: 900px) {
+    .secondary-hero,
+    .secondary-grid,
+    .values-grid {
+        grid-template-columns: 1fr;
+    }
+}

--- a/community.php
+++ b/community.php
@@ -1,10 +1,9 @@
 <?php
 require_once 'includes/functions.php';
 $title = 'Community';
+$extraStylesheets = ['assets/css/secondary-pages.css'];
 include 'includes/header.php';
 ?>
-
-<link href="assets/css/secondary-pages.css" rel="stylesheet">
 
 <div class="secondary-page">
     <section class="secondary-hero" aria-labelledby="community-title">
@@ -20,66 +19,27 @@ include 'includes/header.php';
 
     <section aria-labelledby="values-title">
         <div class="section-heading">
-            <div>
-                <p class="eyebrow">Our values</p>
-                <h2 id="values-title">How we learn and build together</h2>
-            </div>
+            <div><p class="eyebrow">Our values</p><h2 id="values-title">How we learn and build together</h2></div>
             <p>These principles guide project work, presentations and collaboration across the festival community.</p>
         </div>
 
         <div class="values-grid">
-            <article class="value-card">
-                <div class="value-icon" aria-hidden="true">?</div>
-                <h3>Curiosity</h3>
-                <p>We begin with careful observation and questions worth investigating.</p>
-                <details><summary>Read more</summary><p>Students are encouraged to test assumptions, compare approaches and treat unexpected results as useful evidence.</p></details>
-            </article>
-
-            <article class="value-card">
-                <div class="value-icon" aria-hidden="true">✦</div>
-                <h3>Creativity</h3>
-                <p>We turn ideas into experiments, models, prototypes and explanations.</p>
-                <details><summary>Read more</summary><p>Creative work is supported by iteration, feedback and the freedom to revise an idea when evidence suggests a better direction.</p></details>
-            </article>
-
-            <article class="value-card">
-                <div class="value-icon" aria-hidden="true">↔</div>
-                <h3>Collaboration</h3>
-                <p>Strong projects are built through clear roles, discussion and shared responsibility.</p>
-                <details><summary>Read more</summary><p>Students practise listening, explaining decisions and integrating contributions from people with different strengths.</p></details>
-            </article>
-
-            <article class="value-card">
-                <div class="value-icon" aria-hidden="true">+</div>
-                <h3>Belonging</h3>
-                <p>Every learner should have a meaningful way to participate in STEM.</p>
-                <details><summary>Read more</summary><p>Activities are designed with multiple entry points so students can contribute through research, building, coding, design or presentation.</p></details>
-            </article>
-
-            <article class="value-card">
-                <div class="value-icon" aria-hidden="true">◎</div>
-                <h3>Real-world relevance</h3>
-                <p>Projects connect classroom knowledge to health, environment, technology and society.</p>
-                <details><summary>Read more</summary><p>Students are asked to consider evidence, ethics, sustainability and how clearly they can communicate impact.</p></details>
-            </article>
-
-            <article class="value-card">
-                <div class="value-icon" aria-hidden="true">↗</div>
-                <h3>Continuous learning</h3>
-                <p>Progress comes from reflection, feedback and repeated practice.</p>
-                <details><summary>Read more</summary><p>The goal is not only to finish a project, but to understand what changed, what was learned and what should be attempted next.</p></details>
-            </article>
+            <article class="value-card"><div class="value-icon" aria-hidden="true">?</div><h3>Curiosity</h3><p>We begin with careful observation and questions worth investigating.</p><details><summary>Read more</summary><p>Students are encouraged to test assumptions, compare approaches and treat unexpected results as useful evidence.</p></details></article>
+            <article class="value-card"><div class="value-icon" aria-hidden="true">✦</div><h3>Creativity</h3><p>We turn ideas into experiments, models, prototypes and explanations.</p><details><summary>Read more</summary><p>Creative work is supported by iteration, feedback and the freedom to revise an idea when evidence suggests a better direction.</p></details></article>
+            <article class="value-card"><div class="value-icon" aria-hidden="true">↔</div><h3>Collaboration</h3><p>Strong projects are built through clear roles, discussion and shared responsibility.</p><details><summary>Read more</summary><p>Students practise listening, explaining decisions and integrating contributions from people with different strengths.</p></details></article>
+            <article class="value-card"><div class="value-icon" aria-hidden="true">+</div><h3>Belonging</h3><p>Every learner should have a meaningful way to participate in STEM.</p><details><summary>Read more</summary><p>Activities are designed with multiple entry points so students can contribute through research, building, coding, design or presentation.</p></details></article>
+            <article class="value-card"><div class="value-icon" aria-hidden="true">◎</div><h3>Real-world relevance</h3><p>Projects connect classroom knowledge to health, environment, technology and society.</p><details><summary>Read more</summary><p>Students are asked to consider evidence, ethics, sustainability and how clearly they can communicate impact.</p></details></article>
+            <article class="value-card"><div class="value-icon" aria-hidden="true">↗</div><h3>Continuous learning</h3><p>Progress comes from reflection, feedback and repeated practice.</p><details><summary>Read more</summary><p>The goal is not only to finish a project, but to understand what changed, what was learned and what should be attempted next.</p></details></article>
         </div>
     </section>
 
     <section class="secondary-cta" aria-labelledby="community-cta-title">
-        <div>
-            <h2 id="community-cta-title">Take part in the platform</h2>
-            <p>Explore current work or submit a project through the existing festival platform.</p>
-        </div>
+        <div><h2 id="community-cta-title">Take part in the platform</h2><p>Explore current work and learn how projects become part of the festival archive.</p></div>
         <div class="platform-actions">
             <a href="projects.php" class="platform-link primary">Browse projects</a>
-            <a href="upload.php" class="platform-link">Submit a project</a>
+            <?php if (isTeacher() || isAdmin()): ?>
+                <a href="upload.php" class="platform-link">Submit a project</a>
+            <?php endif; ?>
         </div>
     </section>
 </div>

--- a/community.php
+++ b/community.php
@@ -4,138 +4,84 @@ $title = 'Community';
 include 'includes/header.php';
 ?>
 
-<div class="bg-image img1"></div>
-<div class="bg-image img2"></div>
-<div class="bg-image img3"></div>
-<div class="bg-image img4"></div>
-<div class="bg-image img5"></div>
-<div class="bg-image img6"></div>
+<link href="assets/css/secondary-pages.css" rel="stylesheet">
 
-<main class="wrap" aria-labelledby="values-title">
-    <span class="kicker">Our Philosophy</span>
-    <h1 id="values-title">Our STEM Values</h1>
-    <p class="lead">
-      STEM is more than science and technology — it's a mindset. These values guide how we learn, build, and make a real-world impact.
-    </p>
-
-    <section class="grid" aria-label="Interactive list of STEM values">
-      <!-- Card 1: Curiosity -->
-      <article class="card">
-        <div class="icon-wrap" aria-hidden="true">
-          <svg viewBox="0 0 24 24"><path d="M15.5 14h-.79l-.28-.27a6.5 6.5 0 10-.71.71l.27.28v.79L20 21.5 21.5 20l-6-6zm-6 0A4.5 4.5 0 1114 9.5 4.5 4.5 0 019.5 14z"/></svg>
+<div class="secondary-page">
+    <section class="secondary-hero" aria-labelledby="community-title">
+        <div class="secondary-hero-copy">
+            <p class="eyebrow">Festival community</p>
+            <h1 id="community-title">A shared culture of curiosity, care and collaboration</h1>
+            <p class="lead">The festival brings together students, teachers, mentors and families around practical learning and responsible innovation.</p>
         </div>
-        <h3 class="title">Curiosity sparks discovery</h3>
-        <p class="desc">We ask bold questions and explore the "what if?" moments that lead to meaningful breakthroughs.</p>
-        <div class="more" id="more-curiosity" hidden>
-          Curiosity is the starting point of every project we do. We encourage learners to
-          observe closely, form testable questions, and explore multiple paths to an answer.
-          From small experiments to ambitious builds, curiosity keeps momentum high and turns
-          unexpected results into opportunities to learn more.
+        <div class="secondary-hero-media">
+            <img src="assets/images/PHOTO-2025-10-08-18-51-46.jpg" alt="Students and teachers taking part in a festival activity">
         </div>
-        <button class="cta" aria-controls="more-curiosity" aria-expanded="false">Learn more →</button>
-      </article>
-
-      <!-- Card 2: Creativity -->
-      <article class="card">
-        <div class="icon-wrap" aria-hidden="true">
-          <svg viewBox="0 0 24 24"><path d="M9 21h6m-3-2v2m7-10a7 7 0 10-14 0c0 2.5 1.2 4.1 3 5.5.6.5 1 1.2 1 2h6c0-.8.4-1.5 1-2 1.8-1.4 3-3 3-5.5z"/></svg>
-        </div>
-        <h3 class="title">Creativity drives innovation</h3>
-        <p class="desc">We turn imagination into action — designing fresh solutions to tough problems.</p>
-        <div class="more" id="more-creativity" hidden>
-          Creativity in STEM means prototyping fast, learning from feedback, and iterating with purpose.
-          We combine design thinking with technical skills so learners move from ideas to working models.
-          Mistakes are welcomed as signals that help us refine concepts and discover better approaches.
-        </div>
-        <button class="cta" aria-controls="more-creativity" aria-expanded="false">Learn more →</button>
-      </article>
-
-      <!-- Card 3: Collaboration -->
-      <article class="card">
-        <div class="icon-wrap" aria-hidden="true">
-          <svg viewBox="0 0 24 24"><path d="M16 11a4 4 0 10-8 0 4 4 0 008 0zm-10 9a6 6 0 0112 0H6z"/></svg>
-        </div>
-        <h3 class="title">Collaboration makes us stronger</h3>
-        <p class="desc">Great ideas grow when diverse minds work together toward a shared goal.</p>
-        <div class="more" id="more-collaboration" hidden>
-          Teams practice respectful debate, active listening, and clear role-sharing. We use lightweight
-          rituals—stand-ups, retros, and demos—to keep everyone aligned. Collaboration helps us scale ideas
-          faster and ensures that every voice contributes to the final solution.
-        </div>
-        <button class="cta" aria-controls="more-collaboration" aria-expanded="false">Learn more →</button>
-      </article>
-
-      <!-- Card 4: Inclusivity -->
-      <article class="card">
-        <div class="icon-wrap" aria-hidden="true">
-          <svg viewBox="0 0 24 24"><path d="M12 12a5 5 0 11.001-10.001A5 5 0 0112 12zm-7 9a7 7 0 0114 0H5z"/></svg>
-        </div>
-        <h3 class="title">Everyone belongs in STEM</h3>
-        <p class="desc">Diversity fuels progress. We create spaces where every learner feels seen and empowered.</p>
-        <div class="more" id="more-inclusivity" hidden>
-          We design activities with multiple entry points so learners can contribute at different skill levels.
-          Materials, examples, and role models reflect a wide range of backgrounds and perspectives. Belonging
-          isn't a slogan—it's a daily practice that expands who gets to participate and succeed.
-        </div>
-        <button class="cta" aria-controls="more-inclusivity" aria-expanded="false">Learn more →</button>
-      </article>
-
-      <!-- Card 5: Real-World Impact -->
-      <article class="card">
-        <div class="icon-wrap" aria-hidden="true">
-          <svg viewBox="0 0 24 24"><path d="M12 22C6.48 22 2 17.52 2 12S6.48 2 12 2a9.94 9.94 0 018.54 4.69l-1.7 1.13A7.96 7.96 0 0012 4a8 8 0 000 16 8.02 8.02 0 006.84-3.82l1.7 1.13A9.94 9.94 0 0112 22z"/></svg>
-        </div>
-        <h3 class="title">Learning that matters</h3>
-        <p class="desc">We connect knowledge to real-world challenges—making education meaningful and impactful.</p>
-        <div class="more" id="more-impact" hidden>
-          Projects tackle authentic problems—energy, health, environment, accessibility—so learners see how
-          science and engineering improve lives. We emphasize data literacy, ethical choices, and sustainability,
-          helping students measure outcomes and communicate their impact clearly.
-        </div>
-        <button class="cta" aria-controls="more-impact" aria-expanded="false">Learn more →</button>
-      </article>
-
-      <!-- Card 6: Lifelong Learning -->
-      <article class="card">
-        <div class="icon-wrap" aria-hidden="true">
-          <svg viewBox="0 0 24 24"><path d="M12 6v6l4 2m6 4a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
-        </div>
-        <h3 class="title">Grow. Adapt. Keep learning.</h3>
-        <p class="desc">STEM never stops evolving—and neither do we. We embrace curiosity and lifelong growth.</p>
-        <div class="more" id="more-lifelong" hidden>
-          We cultivate habits that compound over time: reflection, feedback, and continuous practice.
-          Learners set goals, track progress, and celebrate iteration. As tools and technologies change,
-          the ability to learn how to learn is the most valuable skill of all.
-        </div>
-        <button class="cta" aria-controls="more-lifelong" aria-expanded="false">Learn more →</button>
-      </article>
     </section>
-</main>
 
-<script>
-  // Scroll reveal
-  const cards = document.querySelectorAll('.card');
-  const reveal = () => {
-    const trigger = window.innerHeight * 0.9;
-    cards.forEach(card => {
-      const top = card.getBoundingClientRect().top;
-      if (top < trigger) card.classList.add('revealed');
-    });
-  };
-  window.addEventListener('scroll', reveal);
-  reveal();
+    <section aria-labelledby="values-title">
+        <div class="section-heading">
+            <div>
+                <p class="eyebrow">Our values</p>
+                <h2 id="values-title">How we learn and build together</h2>
+            </div>
+            <p>These principles guide project work, presentations and collaboration across the festival community.</p>
+        </div>
 
-  // Inline expand/collapse with proper ARIA
-  document.querySelectorAll('.card .cta').forEach(btn => {
-    btn.addEventListener('click', () => {
-      const id = btn.getAttribute('aria-controls');
-      const panel = document.getElementById(id);
-      const expanded = btn.getAttribute('aria-expanded') === 'true';
-      panel.hidden = expanded;
-      btn.setAttribute('aria-expanded', String(!expanded));
-      btn.textContent = expanded ? 'Learn more →' : 'Show less ↑';
-    });
-  });
-</script>
+        <div class="values-grid">
+            <article class="value-card">
+                <div class="value-icon" aria-hidden="true">?</div>
+                <h3>Curiosity</h3>
+                <p>We begin with careful observation and questions worth investigating.</p>
+                <details><summary>Read more</summary><p>Students are encouraged to test assumptions, compare approaches and treat unexpected results as useful evidence.</p></details>
+            </article>
+
+            <article class="value-card">
+                <div class="value-icon" aria-hidden="true">✦</div>
+                <h3>Creativity</h3>
+                <p>We turn ideas into experiments, models, prototypes and explanations.</p>
+                <details><summary>Read more</summary><p>Creative work is supported by iteration, feedback and the freedom to revise an idea when evidence suggests a better direction.</p></details>
+            </article>
+
+            <article class="value-card">
+                <div class="value-icon" aria-hidden="true">↔</div>
+                <h3>Collaboration</h3>
+                <p>Strong projects are built through clear roles, discussion and shared responsibility.</p>
+                <details><summary>Read more</summary><p>Students practise listening, explaining decisions and integrating contributions from people with different strengths.</p></details>
+            </article>
+
+            <article class="value-card">
+                <div class="value-icon" aria-hidden="true">+</div>
+                <h3>Belonging</h3>
+                <p>Every learner should have a meaningful way to participate in STEM.</p>
+                <details><summary>Read more</summary><p>Activities are designed with multiple entry points so students can contribute through research, building, coding, design or presentation.</p></details>
+            </article>
+
+            <article class="value-card">
+                <div class="value-icon" aria-hidden="true">◎</div>
+                <h3>Real-world relevance</h3>
+                <p>Projects connect classroom knowledge to health, environment, technology and society.</p>
+                <details><summary>Read more</summary><p>Students are asked to consider evidence, ethics, sustainability and how clearly they can communicate impact.</p></details>
+            </article>
+
+            <article class="value-card">
+                <div class="value-icon" aria-hidden="true">↗</div>
+                <h3>Continuous learning</h3>
+                <p>Progress comes from reflection, feedback and repeated practice.</p>
+                <details><summary>Read more</summary><p>The goal is not only to finish a project, but to understand what changed, what was learned and what should be attempted next.</p></details>
+            </article>
+        </div>
+    </section>
+
+    <section class="secondary-cta" aria-labelledby="community-cta-title">
+        <div>
+            <h2 id="community-cta-title">Take part in the platform</h2>
+            <p>Explore current work or submit a project through the existing festival platform.</p>
+        </div>
+        <div class="platform-actions">
+            <a href="projects.php" class="platform-link primary">Browse projects</a>
+            <a href="upload.php" class="platform-link">Submit a project</a>
+        </div>
+    </section>
+</div>
 
 <?php include 'includes/footer.php'; ?>

--- a/includes/header.php
+++ b/includes/header.php
@@ -13,6 +13,7 @@
     <link href="assets/css/content.css" rel="stylesheet">
     <link href="assets/css/content-review-fixes.css" rel="stylesheet">
     <link href="assets/css/platform-positioning.css" rel="stylesheet">
+    <link href="assets/css/listing-pages.css" rel="stylesheet">
     <script src="assets/js/main.js" defer></script>
     <script src="assets/js/content-review-fixes.js" defer></script>
 </head>

--- a/includes/header.php
+++ b/includes/header.php
@@ -14,6 +14,9 @@
     <link href="assets/css/content-review-fixes.css" rel="stylesheet">
     <link href="assets/css/platform-positioning.css" rel="stylesheet">
     <link href="assets/css/listing-pages.css" rel="stylesheet">
+    <?php foreach (($extraStylesheets ?? []) as $stylesheet): ?>
+        <link href="<?php echo htmlspecialchars($stylesheet); ?>" rel="stylesheet">
+    <?php endforeach; ?>
     <script src="assets/js/main.js" defer></script>
     <script src="assets/js/content-review-fixes.js" defer></script>
 </head>

--- a/news.php
+++ b/news.php
@@ -4,89 +4,83 @@ $title = 'News';
 include 'includes/header.php';
 ?>
 
-<section id="news" class="news">
-  <h2>Latest News</h2>
-  <p class="news-intro">Stay up to date with the latest from our Nikola Tesla Science Fair Festival — from student breakthroughs to upcoming events and inspiring stories.</p>
-
-  <div class="news-grid">
-     <!-- News Item 1 -->
-    <article class="news-card">
-      <embed id="pdf_day1" src="assets/pdfs/Newsletter- DAY 1.pdf" type="application/pdf" onClick="showPdf()" width="100%" height="100%">
-    </article>
-
-     <!-- News Item 2 -->
-    <article class="news-card">
-      <embed id="pdf_day2" src="assets/pdfs/Newsletter- DAY 2.pdf" type="application/pdf" onClick="showPdf()" width="100%" height="100%">
-    </article>
-
-    <!-- News Item 3-->
-    <article class="news-card">
-      <embed id="pdf_day3" src="assets/pdfs/Newsletter- DAY 3.pdf" type="application/pdf" onClick="showPdf()" width="100%" height="100%">
-    </article>
-
-    <!-- News Item 4-->
-    <article class="news-card">
-      <embed id="pdf_day4" src="assets/pdfs/Newsletter- DAY 4.pdf" type="application/pdf" onClick="showPdf()" width="100%" height="100%">
-    </article>
-
-    <div class="years-grid">
-      <!-- 2022 -->
-      <article class="year-card">
-        <div class="year-header">
-          <div class="year-badge">2022</div>
-          <h3>Nikola Tesla Magazine — 2022</h3>
-          <p class="year-desc">Rezumatul festivalului: interviuri, proiecte, rezultate & momente cheie.</p>
-        </div>
-        <div class="year-days">
-          <button class="chip open-pdf" data-pdf="assets/pdfs/Newsletter- DAY 1.pdf" data-title="2022 • Day 1">Day 1</button>
-          <button class="chip open-pdf" data-pdf="assets/pdfs/Newsletter- DAY 2.pdf" data-title="2022 • Day 2">Day 2</button>
-          <button class="chip open-pdf" data-pdf="assets/pdfs/Newsletter- DAY 3.pdf" data-title="2022 • Day 3">Day 3</button>
-        </div>
-      </article>
-
-      <!-- 2024 -->
-      <article class="year-card">
-        <div class="year-header">
-          <div class="year-badge">2024</div>
-          <h3>Nikola Tesla Magazine — 2024</h3>
-          <p class="year-desc">Creștere majoră a participării, secțiuni noi și proiecte premiate.</p>
-        </div>
-        <div class="year-days">
-          <button class="chip open-pdf" data-pdf="/pdf/2024/NT-2024-day1.pdf" data-title="2024 • Day 1">Day 1</button>
-          <button class="chip open-pdf" data-pdf="/pdf/2024/NT-2024-day2.pdf" data-title="2024 • Day 2">Day 2</button>
-        </div>
-      </article>
-
-      <!-- 2023 -->
-      <article class="year-card">
-        <div class="year-header">
-          <div class="year-badge">2023</div>
-          <h3>Nikola Tesla Magazine — 2023</h3>
-          <p class="year-desc">Robotică, energie verde și primele colaborări internaționale.</p>
-        </div>
-        <div class="year-days">
-          <button class="chip open-pdf" data-pdf="/pdf/2023/NT-2023-day1.pdf" data-title="2023 • Day 1">Day 1</button>
-          <button class="chip open-pdf" data-pdf="/pdf/2023/NT-2023-day2.pdf" data-title="2023 • Day 2">Day 2</button>
-        </div>
-      </article>
+<section class="news-hero" aria-labelledby="news-title">
+    <div>
+        <p class="eyebrow">News and publications</p>
+        <h1 id="news-title">Festival stories, newsletters and project catalogues</h1>
+        <p>Follow the programme through daily newsletters and explore the bilingual publications produced around major student projects.</p>
     </div>
-  </div>
+    <div class="news-actions">
+        <a href="projects.php" class="platform-link primary">Browse projects</a>
+        <a href="about.php" class="platform-link">About the festival</a>
+    </div>
 </section>
 
-<!-- MODAL PDF VIEWER -->
-<div class="pdf-modal" id="pdfModal" aria-hidden="true">
-  <div class="pdf-dialog" role="dialog" aria-modal="true" aria-labelledby="pdfTitle">
-    <button class="pdf-close" aria-label="Close">×</button>
-    <div class="pdf-toolbar">
-      <h4 id="pdfTitle">Magazine</h4>
-      <div class="pdf-actions">
-        <button id="zoomOut" class="btn-ghost" aria-label="Zoom out">−</button>
-        <button id="zoomIn" class="btn-ghost" aria-label="Zoom in">+</button>
-        <a id="pdfDownload" class="btn-ghost" download>Download</a>
-      </div>
+<section class="content-section" aria-labelledby="daily-newsletters-title">
+    <div class="section-heading">
+        <div>
+            <p class="eyebrow">Festival newsletters</p>
+            <h2 id="daily-newsletters-title">Follow the programme day by day</h2>
+        </div>
+        <p>Open each issue in the browser or download it for later reading.</p>
     </div>
-    <iframe id="pdfFrame" title="PDF viewer"></iframe>
-  </div>
-</div>
+
+    <div class="news-grid-modern">
+        <?php for ($day = 1; $day <= 4; $day++): ?>
+            <?php $file = 'assets/pdfs/Newsletter- DAY ' . $day . '.pdf'; ?>
+            <article class="news-document-card">
+                <p class="eyebrow">Festival journal</p>
+                <h2>Newsletter — Day <?php echo $day; ?></h2>
+                <p>Highlights, interviews, activities and project moments from the festival programme.</p>
+                <div class="news-document-actions">
+                    <a class="platform-link primary" href="<?php echo htmlspecialchars($file); ?>" target="_blank" rel="noopener noreferrer">Open PDF</a>
+                    <a class="platform-link" href="<?php echo htmlspecialchars($file); ?>" download>Download</a>
+                </div>
+            </article>
+        <?php endfor; ?>
+    </div>
+</section>
+
+<section class="content-section" aria-labelledby="catalogues-title">
+    <div class="section-heading">
+        <div>
+            <p class="eyebrow">Project publications</p>
+            <h2 id="catalogues-title">Bilingual catalogues</h2>
+        </div>
+        <p>Romanian and English editions documenting recent interdisciplinary projects.</p>
+    </div>
+
+    <div class="news-grid-modern">
+        <article class="news-year-card">
+            <p class="eyebrow">Ecology · 2026</p>
+            <h2>Paradis Educational Apiary</h2>
+            <p>Pollination, ecosystems and experiential learning at Tansa.</p>
+            <div class="news-document-actions">
+                <a class="platform-link primary" href="assets/pdfs/stupina-paradis-2026-ro.pdf">Romanian</a>
+                <a class="platform-link" href="assets/pdfs/stupina-paradis-2026-en.pdf">English</a>
+            </div>
+        </article>
+
+        <article class="news-year-card">
+            <p class="eyebrow">Chemistry · 2026</p>
+            <h2>Floreal</h2>
+            <p>A student project connecting fragrance formulation, product design and presentation.</p>
+            <div class="news-document-actions">
+                <a class="platform-link primary" href="assets/pdfs/floreal-2026-ro.pdf">Romanian</a>
+                <a class="platform-link" href="assets/pdfs/floreal-2026-en.pdf">English</a>
+            </div>
+        </article>
+
+        <article class="news-year-card">
+            <p class="eyebrow">Biology · 2025</p>
+            <h2>Paradis Butterfly Farm</h2>
+            <p>Observation, habitats, life cycles and biodiversity presented through a practical programme.</p>
+            <div class="news-document-actions">
+                <a class="platform-link primary" href="assets/pdfs/ferma-de-fluturi-2025-ro.pdf">Romanian</a>
+                <a class="platform-link" href="assets/pdfs/ferma-de-fluturi-2025-en.pdf">English</a>
+            </div>
+        </article>
+    </div>
+</section>
 
 <?php include 'includes/footer.php'; ?>

--- a/preview/about.html
+++ b/preview/about.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#07154f">
+    <title>About Us — Paradis Science Festival</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/assets/css/main.css" rel="stylesheet">
+    <link href="/assets/css/refinement.css" rel="stylesheet">
+    <link href="/assets/css/content.css" rel="stylesheet">
+    <link href="/assets/css/platform-positioning.css" rel="stylesheet">
+    <link href="/assets/css/secondary-pages.css" rel="stylesheet">
+</head>
+<body class="static-preview">
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <nav id="navbar" aria-label="Primary navigation">
+        <div class="navbar-shell">
+            <a class="navbar-brand-link" href="/preview/"><span class="brand-label">Paradis Science Festival</span></a>
+            <div class="navbar-links"><a href="/preview/">Home</a><a href="/preview/projects.html">Projects</a><a href="/preview/community.html">Community</a></div>
+            <div class="navbar-account"><a class="nav-action" href="/preview/submit.html">Submit a project</a></div>
+        </div>
+    </nav>
+    <main id="main-content" class="container mt-4">
+        <div class="secondary-page">
+            <section class="secondary-hero" aria-labelledby="about-title">
+                <div class="secondary-hero-copy"><p class="eyebrow">About the festival</p><h1 id="about-title">Where student curiosity becomes visible work</h1><p class="lead">Paradis Science Festival is a public showcase, project platform and archive for student-led science, engineering and interdisciplinary learning.</p></div>
+                <div class="secondary-hero-media"><img src="/assets/images/experiments kids.jpg" alt="Students conducting science experiments"></div>
+            </section>
+            <section aria-labelledby="purpose-title">
+                <div class="section-heading"><div><p class="eyebrow">Purpose</p><h2 id="purpose-title">More than a one-day exhibition</h2></div><p>The festival gives students a place to investigate, build, present and revisit their work over time.</p></div>
+                <div class="secondary-grid">
+                    <article class="secondary-card"><h3>Learn through making</h3><p>Students test ideas through experiments, prototypes, observation, research and iteration.</p></article>
+                    <article class="secondary-card"><h3>Present with confidence</h3><p>Projects are explained to peers, teachers, families and external guests in a public setting.</p></article>
+                    <article class="secondary-card"><h3>Connect disciplines</h3><p>Science, engineering, design, ecology, chemistry and digital tools meet in practical work.</p></article>
+                    <article class="secondary-card"><h3>Build an archive</h3><p>Projects, publications, media and results remain available beyond the event itself.</p></article>
+                </div>
+            </section>
+            <section class="secondary-grid" aria-label="Mission and vision">
+                <article class="secondary-card"><p class="eyebrow">Mission</p><h2>Make STEM active and accessible</h2><p>We create structured opportunities for students to ask better questions, develop practical skills and communicate what they discover.</p></article>
+                <article class="secondary-card"><p class="eyebrow">Vision</p><h2>A school culture where ideas are built</h2><p>We want experimentation, collaboration and responsible innovation to become normal parts of everyday learning.</p></article>
+            </section>
+            <section class="secondary-cta" aria-labelledby="about-cta-title"><div><h2 id="about-cta-title">See what students have created</h2><p>Browse current projects, project films and bilingual publications.</p></div><a href="/preview/projects.html" class="platform-link primary">Browse projects</a></section>
+        </div>
+    </main>
+</body>
+</html>

--- a/preview/community.html
+++ b/preview/community.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="theme-color" content="#07154f">
+    <title>Community — Paradis Science Festival</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/assets/css/main.css" rel="stylesheet">
+    <link href="/assets/css/refinement.css" rel="stylesheet">
+    <link href="/assets/css/content.css" rel="stylesheet">
+    <link href="/assets/css/platform-positioning.css" rel="stylesheet">
+    <link href="/assets/css/secondary-pages.css" rel="stylesheet">
+</head>
+<body class="static-preview">
+    <a class="skip-link" href="#main-content">Skip to main content</a>
+    <nav id="navbar" aria-label="Primary navigation">
+        <div class="navbar-shell">
+            <a class="navbar-brand-link" href="/preview/"><span class="brand-label">Paradis Science Festival</span></a>
+            <div class="navbar-links"><a href="/preview/">Home</a><a href="/preview/projects.html">Projects</a><a href="/preview/about.html">About</a></div>
+            <div class="navbar-account"><a class="nav-action" href="/preview/submit.html">Submit a project</a></div>
+        </div>
+    </nav>
+    <main id="main-content" class="container mt-4">
+        <div class="secondary-page">
+            <section class="secondary-hero" aria-labelledby="community-title">
+                <div class="secondary-hero-copy"><p class="eyebrow">Festival community</p><h1 id="community-title">A shared culture of curiosity, care and collaboration</h1><p class="lead">The festival brings together students, teachers, mentors and families around practical learning and responsible innovation.</p></div>
+                <div class="secondary-hero-media"><img src="/assets/images/PHOTO-2025-10-08-18-51-46.jpg" alt="Students and teachers taking part in a festival activity"></div>
+            </section>
+            <section aria-labelledby="values-title">
+                <div class="section-heading"><div><p class="eyebrow">Our values</p><h2 id="values-title">How we learn and build together</h2></div><p>These principles guide project work, presentations and collaboration across the festival community.</p></div>
+                <div class="values-grid">
+                    <article class="value-card"><div class="value-icon" aria-hidden="true">?</div><h3>Curiosity</h3><p>We begin with careful observation and questions worth investigating.</p><details><summary>Read more</summary><p>Students are encouraged to test assumptions, compare approaches and treat unexpected results as useful evidence.</p></details></article>
+                    <article class="value-card"><div class="value-icon" aria-hidden="true">✦</div><h3>Creativity</h3><p>We turn ideas into experiments, models, prototypes and explanations.</p><details><summary>Read more</summary><p>Creative work is supported by iteration, feedback and the freedom to revise an idea when evidence suggests a better direction.</p></details></article>
+                    <article class="value-card"><div class="value-icon" aria-hidden="true">↔</div><h3>Collaboration</h3><p>Strong projects are built through clear roles, discussion and shared responsibility.</p><details><summary>Read more</summary><p>Students practise listening, explaining decisions and integrating contributions from people with different strengths.</p></details></article>
+                    <article class="value-card"><div class="value-icon" aria-hidden="true">+</div><h3>Belonging</h3><p>Every learner should have a meaningful way to participate in STEM.</p><details><summary>Read more</summary><p>Activities are designed with multiple entry points so students can contribute through research, building, coding, design or presentation.</p></details></article>
+                    <article class="value-card"><div class="value-icon" aria-hidden="true">◎</div><h3>Real-world relevance</h3><p>Projects connect classroom knowledge to health, environment, technology and society.</p><details><summary>Read more</summary><p>Students are asked to consider evidence, ethics, sustainability and how clearly they can communicate impact.</p></details></article>
+                    <article class="value-card"><div class="value-icon" aria-hidden="true">↗</div><h3>Continuous learning</h3><p>Progress comes from reflection, feedback and repeated practice.</p><details><summary>Read more</summary><p>The goal is not only to finish a project, but to understand what changed, what was learned and what should be attempted next.</p></details></article>
+                </div>
+            </section>
+            <section class="secondary-cta" aria-labelledby="community-cta-title"><div><h2 id="community-cta-title">Take part in the platform</h2><p>Explore current work or submit a project through the existing festival platform.</p></div><div class="platform-actions"><a href="/preview/projects.html" class="platform-link primary">Browse projects</a><a href="/preview/submit.html" class="platform-link">Submit a project</a></div></section>
+        </div>
+    </main>
+</body>
+</html>

--- a/preview/index.html
+++ b/preview/index.html
@@ -20,8 +20,8 @@
 
     <nav id="navbar" aria-label="Primary navigation">
         <div class="navbar-shell">
-            <a class="navbar-brand-link" href="#top" aria-label="Nikola Tesla Science Festival home">
-                <span class="brand-label">Nikola Tesla Science Festival</span>
+            <a class="navbar-brand-link" href="#top" aria-label="Paradis Science Festival home">
+                <span class="brand-label">Paradis Science Festival</span>
             </a>
             <div class="navbar-links" aria-label="Festival pages">
                 <a href="#achievements">Achievements</a>
@@ -29,10 +29,12 @@
                 <a href="#films">Films</a>
                 <a href="#publications">Publications</a>
                 <a href="#gallery">Gallery</a>
+                <a href="/preview/about.html">About</a>
+                <a href="/preview/community.html">Community</a>
             </div>
             <div class="navbar-account" aria-label="Platform actions">
-                <a class="nav-account-link" href="/projects.php">Browse projects</a>
-                <a class="nav-action" href="/upload.php">Submit a project</a>
+                <a class="nav-account-link" href="/preview/projects.html">Browse projects</a>
+                <a class="nav-action" href="/preview/submit.html">Submit a project</a>
             </div>
         </div>
     </nav>
@@ -41,7 +43,7 @@
         <div class="container site-header-inner">
             <div class="site-header-copy">
                 <p class="site-kicker">Paradis International College</p>
-                <h1 class="logo">Nikola Tesla <span>Science Festival</span></h1>
+                <h1 class="logo">Paradis <span>Science Festival</span></h1>
                 <p class="tagline">A project platform, public showcase and archive for student-led science.</p>
             </div>
             <img src="/assets/images/download paradis college.png" alt="Paradis International College logo" class="site-logo-image">
@@ -56,8 +58,8 @@
                 <p>The website combines three roles: a public festival showcase, a project submission platform and a year-by-year archive of student work and results.</p>
             </div>
             <div class="platform-actions">
-                <a class="platform-link primary" href="/projects.php">Browse all projects</a>
-                <a class="platform-link" href="/upload.php">Submit a project</a>
+                <a class="platform-link primary" href="/preview/projects.html">Browse all projects</a>
+                <a class="platform-link" href="/preview/submit.html">Submit a project</a>
             </div>
         </section>
 
@@ -75,7 +77,7 @@
                     <h2>Junior Inventor Award Trophy</h2>
                     <p>Paradis International College received the Junior Inventor Award Trophy for its outstanding scientific contribution to research at the INVENTICA 2026 International Exhibition.</p>
                     <ul>
-                        <li><strong>Gold Medal:</strong> MechaByte and the WARD robot</li>
+                        <li><strong>Gold Medal:</strong> MechaByte and the WARDA robot</li>
                         <li><strong>Silver Medal:</strong> Healer’s Pharmacy</li>
                         <li><strong>Bronze Medals:</strong> Techno Wizards FLL Team and Ștefan Albu with Exoneuron</li>
                     </ul>
@@ -116,11 +118,11 @@
         </section>
 
         <section class="content-section" id="publications" aria-labelledby="publications-title">
-            <div class="section-heading"><div><p class="eyebrow">Project catalogues</p><h2 id="publications-title">Read the bilingual publications</h2></div><p>The current preview links to the Drive originals; compressed local editions can replace them later.</p></div>
+            <div class="section-heading"><div><p class="eyebrow">Project catalogues</p><h2 id="publications-title">Read the bilingual publications</h2></div><p>Compressed local editions are available for each project in Romanian and English.</p></div>
             <div class="publications-grid">
-                <article class="publication-card"><h3>Paradis Educational Apiary — Tansa 2026</h3><p>Romanian and English catalogues.</p><div class="publication-meta"><a href="https://drive.google.com/file/d/1a5D0Hl6_nLnOlBmnmKuXNQaTv-9lNr_v/view" target="_blank" rel="noopener noreferrer">Romanian PDF</a><br><a href="https://drive.google.com/file/d/1TSbLFIomSwyx25xgyD7SSfchvwsKMwfY/view" target="_blank" rel="noopener noreferrer">English PDF</a></div></article>
-                <article class="publication-card"><h3>Floreal — January 2026</h3><p>Bilingual project catalogue.</p><div class="publication-meta"><a href="https://drive.google.com/file/d/1TllCy7DV8o1AtsZ0QLjO_4HwkXftR2Uk/view" target="_blank" rel="noopener noreferrer">Romanian PDF</a><br><a href="https://drive.google.com/file/d/1_3L4jV5I9OWL0-oyyvwPhnrfHadwyqeA/view" target="_blank" rel="noopener noreferrer">English PDF</a></div></article>
-                <article class="publication-card"><h3>Butterfly Farm — November 2025</h3><p>Romanian and English catalogues with supporting material.</p><div class="publication-meta"><a href="https://drive.google.com/file/d/1AqRe3VyCl9McsoCWodtrfqo8gCPjTkAL/view" target="_blank" rel="noopener noreferrer">Romanian PDF</a><br><a href="https://drive.google.com/file/d/1ppM-2gQ9nOgjsh8aF2vJk6WPERyr6N8j/view" target="_blank" rel="noopener noreferrer">English PDF</a></div></article>
+                <article class="publication-card"><h3>Paradis Educational Apiary — Tansa 2026</h3><p>Romanian and English catalogues.</p><div class="publication-meta"><a href="/assets/pdfs/stupina-paradis-2026-ro.pdf">Romanian PDF</a><br><a href="/assets/pdfs/stupina-paradis-2026-en.pdf">English PDF</a></div></article>
+                <article class="publication-card"><h3>Floreal — January 2026</h3><p>Bilingual project catalogue.</p><div class="publication-meta"><a href="/assets/pdfs/floreal-2026-ro.pdf">Romanian PDF</a><br><a href="/assets/pdfs/floreal-2026-en.pdf">English PDF</a></div></article>
+                <article class="publication-card"><h3>Butterfly Farm — November 2025</h3><p>Romanian and English catalogues with supporting material.</p><div class="publication-meta"><a href="/assets/pdfs/ferma-de-fluturi-2025-ro.pdf">Romanian PDF</a><br><a href="/assets/pdfs/ferma-de-fluturi-2025-en.pdf">English PDF</a></div></article>
             </div>
         </section>
 
@@ -150,6 +152,6 @@
         </section>
     </main>
 
-    <footer class="text-light mt-5 py-4"><div class="container"><div class="row align-items-center"><div class="col-md-7"><h5>Nikola Tesla Science Festival</h5><p class="mb-0">Public festival showcase, project platform and archive. PHP, authentication and database functionality remain on the existing deployment.</p></div><div class="col-md-5 text-md-end"><small>Paradis International College</small></div></div></div></footer>
+    <footer class="text-light mt-5 py-4"><div class="container"><div class="row align-items-center"><div class="col-md-7"><h5>Paradis Science Festival</h5><p class="mb-0">Public festival showcase, project platform and archive. PHP, authentication and database functionality remain on the existing deployment.</p></div><div class="col-md-5 text-md-end"><small>Paradis International College</small></div></div></div></footer>
 </body>
 </html>

--- a/projects.php
+++ b/projects.php
@@ -1,135 +1,115 @@
 <?php
-// Include core functions and handle project filtering
 require_once 'includes/functions.php';
 
-// Get filter options from URL
 $year = isset($_GET['year']) ? $_GET['year'] : null;
 $sort = isset($_GET['sort']) ? $_GET['sort'] : 'votes';
-
-// Get projects (optionally filtered by year)
 $projects = getProjects($year);
 
-// Sort projects based on user selection
 if ($sort === 'date') {
-    // Sort by most recent first
     usort($projects, function($a, $b) {
         return strtotime($b['created_at']) - strtotime($a['created_at']);
     });
 } elseif ($sort === 'title') {
-    // Sort alphabetically by title
     usort($projects, function($a, $b) {
         return strcmp($a['title'], $b['title']);
     });
 }
-// Default is by votes (already sorted in getProjects)
 
-// Get all available years for filter dropdown
 $years = getYears();
-
-// Set page title
 $title = 'All Projects';
 include 'includes/header.php';
 ?>
 
-<div class="pres-hero">
-  <h2>Student Presentations</h2>
-  <p class="pres-intro">
-    A stage for bold ideas and real-world problem solving — From a single idea to a working prototype — our students prove that science is an adventure, not a formula.
-    Here, experiments turn into breakthroughs, and passion turns into purpose.
-  </p>
+<section class="archive-hero" aria-labelledby="projects-title">
+    <div>
+        <p class="eyebrow">Project archive</p>
+        <h1 id="projects-title">Student projects</h1>
+        <p>Browse festival work by year, popularity or title. Each project keeps its description, media, votes and discussion in one place.</p>
+    </div>
+    <div class="archive-actions">
+        <?php if (isTeacher() || isAdmin()): ?>
+            <a href="upload.php" class="platform-link primary">Submit a project</a>
+        <?php endif; ?>
+        <a href="news.php" class="platform-link">Festival news</a>
+    </div>
+</section>
 
-  <div class="pres-cta">
-    <?php if (isTeacher() || isAdmin()): ?>
-      <a href="upload.php" class="btn">Submit Your Project →</a>
-    <?php endif; ?>
-    <a href="news.php" class="btn secondary">Get Updates →</a>
-  </div>
+<div class="archive-toolbar" aria-label="Project filters">
+    <form method="GET">
+        <label class="visually-hidden" for="project-year">Filter by year</label>
+        <select id="project-year" name="year" onchange="this.form.submit()">
+            <option value="">All years</option>
+            <?php foreach ($years as $yearOption): ?>
+                <option value="<?php echo htmlspecialchars($yearOption); ?>" <?php echo $year == $yearOption ? 'selected' : ''; ?>>
+                    <?php echo htmlspecialchars($yearOption); ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+        <input type="hidden" name="sort" value="<?php echo htmlspecialchars($sort); ?>">
+    </form>
 
-  <!-- Filter controls -->
-  <div class="pres-filters">
-    <form method="GET" style="display: inline;">
-      <select name="year" class="chip" onchange="this.form.submit()" style="appearance: auto; cursor: pointer;">
-        <option value="">All Years</option>
-        <?php foreach ($years as $yearOption): ?>
-          <option value="<?php echo $yearOption; ?>" <?php echo $year == $yearOption ? 'selected' : ''; ?>>
-            <?php echo $yearOption; ?>
-          </option>
-        <?php endforeach; ?>
-      </select>
-      <input type="hidden" name="sort" value="<?php echo htmlspecialchars($sort); ?>">
+    <form method="GET">
+        <label class="visually-hidden" for="project-sort">Sort projects</label>
+        <select id="project-sort" name="sort" onchange="this.form.submit()">
+            <option value="votes" <?php echo $sort === 'votes' ? 'selected' : ''; ?>>Most voted</option>
+            <option value="date" <?php echo $sort === 'date' ? 'selected' : ''; ?>>Most recent</option>
+            <option value="title" <?php echo $sort === 'title' ? 'selected' : ''; ?>>Title A–Z</option>
+        </select>
+        <input type="hidden" name="year" value="<?php echo htmlspecialchars((string)$year); ?>">
     </form>
-    
-    <form method="GET" style="display: inline; margin-left: 10px;">
-      <select name="sort" class="chip" onchange="this.form.submit()" style="appearance: auto; cursor: pointer;">
-        <option value="votes" <?php echo $sort === 'votes' ? 'selected' : ''; ?>>By Votes</option>
-        <option value="date" <?php echo $sort === 'date' ? 'selected' : ''; ?>>By Date</option>
-        <option value="title" <?php echo $sort === 'title' ? 'selected' : ''; ?>>By Title</option>
-      </select>
-      <input type="hidden" name="year" value="<?php echo htmlspecialchars($year); ?>">
-    </form>
-  </div>
 </div>
 
-<!-- Projects grid -->
 <?php if (empty($projects)): ?>
-  <div class="pres-grid">
-    <article class="pres-card skeleton">
-      <div class="thumb skeleton-box"></div>
-      <div class="meta">
-        <h3 class="title skeleton-line">No projects yet</h3>
-        <p class="desc skeleton-line">
-          <?php if ($year): ?>
-            No projects were submitted in <?php echo $year; ?>.
-          <?php else: ?>
-            Be the first to upload a project!
-          <?php endif; ?>
+    <section class="secondary-card" aria-live="polite">
+        <p class="eyebrow">No results</p>
+        <h2>No projects found</h2>
+        <p>
+            <?php if ($year): ?>
+                No projects were submitted in <?php echo htmlspecialchars($year); ?>.
+            <?php else: ?>
+                No projects have been published yet.
+            <?php endif; ?>
         </p>
-        <span class="badge">Coming soon</span>
-      </div>
-    </article>
-  </div>
+    </section>
 <?php else: ?>
-  <div class="pres-grid">
-    <?php foreach ($projects as $project): ?>
-      <article class="pres-card">
-        <a href="project.php?id=<?php echo $project['id']; ?>" style="text-decoration: none; color: inherit;">
-          <div class="thumb" style="background: linear-gradient(135deg, #667eea 0%, #764ba2 100%); display: flex; align-items: center; justify-content: center; color: white; font-size: 3rem;">
-            🔬
-          </div>
-          <div class="meta">
-            <h3 class="title"><?php echo htmlspecialchars($project['title']); ?></h3>
-            <p class="desc">
-              <?php 
-                if ($project['description']) {
-                  echo htmlspecialchars(substr($project['description'], 0, 100)); 
-                  echo strlen($project['description']) > 100 ? '...' : '';
-                } else {
-                  echo 'View project details';
-                }
-              ?>
-            </p>
-            <div style="display: flex; justify-content: space-between; align-items: center;">
-              <span class="badge"><?php echo $project['year']; ?></span>
-              <span class="badge" style="background: #ef4444;">
-                <i class="fas fa-heart"></i> <?php echo $project['vote_count']; ?>
-              </span>
-            </div>
-            <p style="color: var(--muted); font-size: 0.9rem; margin-top: 8px;">
-              by <?php echo htmlspecialchars($project['author_name']); ?>
-            </p>
-          </div>
-        </a>
-      </article>
-    <?php endforeach; ?>
-  </div>
+    <section class="project-archive-grid" aria-label="Published student projects">
+        <?php foreach ($projects as $project): ?>
+            <article class="project-archive-card">
+                <a class="project-archive-link" href="project.php?id=<?php echo (int)$project['id']; ?>">
+                    <div class="project-archive-thumb" aria-hidden="true"><i class="fas fa-flask"></i></div>
+                    <div class="project-archive-body">
+                        <h2><?php echo htmlspecialchars($project['title']); ?></h2>
+                        <p>
+                            <?php
+                            if (!empty($project['description'])) {
+                                $description = $project['description'];
+                                echo htmlspecialchars(mb_substr($description, 0, 130));
+                                echo mb_strlen($description) > 130 ? '…' : '';
+                            } else {
+                                echo 'Open the project to view its research, media and results.';
+                            }
+                            ?>
+                        </p>
+                        <div class="project-archive-meta">
+                            <div class="project-archive-meta-row">
+                                <span class="badge bg-secondary"><?php echo htmlspecialchars($project['year']); ?></span>
+                                <span class="badge bg-danger"><i class="fas fa-heart" aria-hidden="true"></i> <?php echo (int)$project['vote_count']; ?></span>
+                            </div>
+                            <p class="project-archive-author">By <?php echo htmlspecialchars($project['author_name']); ?></p>
+                        </div>
+                    </div>
+                </a>
+            </article>
+        <?php endforeach; ?>
+    </section>
 <?php endif; ?>
 
 <p class="pres-note">
-  <?php if (isTeacher() || isAdmin()): ?>
-    Submissions are open. <a href="upload.php">Upload your project</a> and share your innovation!
-  <?php else: ?>
-    Want to see your project featured here? Contact a teacher to submit your work.
-  <?php endif; ?>
+    <?php if (isTeacher() || isAdmin()): ?>
+        Submissions are open. <a href="upload.php">Upload a project</a> and add it to the archive.
+    <?php else: ?>
+        Students can work with a teacher to publish a project on the platform.
+    <?php endif; ?>
 </p>
 
 <?php include 'includes/footer.php'; ?>


### PR DESCRIPTION
Follow-up frontend cleanup for secondary pages affected by the new shared visual system.

Included:
- coherent About page and responsive Community values page;
- dedicated static previews for About and Community;
- refined project archive with clearer filters and cards;
- redesigned News page around working newsletters and local bilingual catalogues;
- stronger global contrast for Upload Project and Register navigation actions;
- isolated `secondary-pages.css` and `listing-pages.css` layers;
- preserved PHP routes, authentication, voting, uploads and database behavior;
- responsive and keyboard-accessible interactions.

The individual `project.php` page remains functionally unchanged because its existing structure is already acceptable; shared card and navigation refinements still improve its presentation.

Before merge, Copilot findings were addressed by moving page-specific stylesheets into the document head and restricting the Community upload CTA to teachers/admins.